### PR TITLE
use monospace font for code in table

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -38,7 +38,7 @@ h5 {
     font-size: 1em;
 }
 
-h2 code, h3 code, h4 code, h5 code, td code {
+h2 code, h3 code, h4 code, h5 code {
     font-family: inherit !important;
     font-size: inherit !important;
 }


### PR DESCRIPTION
The verbatim or code markup of fonts in tables does not work: This table

```
  | =verbatim= | text      |
  | ~code~     | more text |
```
does not display properly, while this inline markup is fine: =verbatim= and ~code~.